### PR TITLE
[TC2] Created score suggested user function & renamed BFS function

### DIFF
--- a/server/utils/getFollowingDistances.js
+++ b/server/utils/getFollowingDistances.js
@@ -1,8 +1,8 @@
-const { getFollowing } = require('../utils/getFollowing')
+const { getFollowing } = require('./getFollowing')
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
-async function bfsFollowing(currentUserID) {
+async function getFollowingDistances(currentUserID) {
 
     // queue of users to check at current level
     let usersToCheck = [currentUserID];
@@ -35,4 +35,4 @@ async function bfsFollowing(currentUserID) {
     return distance;
 };
 
-module.exports = { bfsFollowing };
+module.exports = { getFollowingDistances };

--- a/server/utils/scoreSuggestedFollowers.js
+++ b/server/utils/scoreSuggestedFollowers.js
@@ -1,0 +1,29 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+const { getFollowingDistances } = require('../utils/getFollowingDistances');
+const { cosineSimilarity } = require('../math/cosineSimilarity');
+
+async function scoreSuggestedFollowers(currentUserID) {
+
+    const distanceArray = await getFollowingDistances(currentUserID)
+    const scores = new Map();
+
+    // assign set values for scoring formula
+    const a = 1;
+    const r = 0.29;
+
+    // start from distance = 2 (skip distance[0]: current user, and distance[1] users already followed)
+    for (let distance = 2; distance < distanceArray.length; distance++) {
+        const usersAtDistance = distanceArray[distance];
+        const scoreForDistance = a * Math.pow(1 - r, distance);
+        // set the new scores for each userID in the Map object
+         for (const userID of usersAtDistance) {
+            scores.set(userID, scoreForDistance)
+         }
+    }
+
+    return scores;
+
+}
+
+module.exports = { scoreSuggestedFollowers }


### PR DESCRIPTION
Context:
- TC2 focuses on using a graphing algorithm to suggest users to follow based on how far they are in the chain of mutuals relative to the current user.
- This PR implements scoring logic for those distances using logarithmic scoring, which is explained below.

Description:
- Renamed bfsFollowing function to getFollowingDistances for more clarity.
- Created `scoreSuggestedFollowers` function.
- Function takes in `currentUserID` as only parameter.
- `currentUserID` is used to get the following `distanceArray` by calling `getFollowingDistances` function. 
- Initializes a `scores` Map to assign each suggested userID a score based on their distance.
- Begins scoring from `distance = 2 ` because it skips over the current user (distance[0]) and the people the user is directly following (distance[1]). This is so scoring beings with users not directly followed by the current user.
- Then, the function iterates over each array of userIDs at each distance within `distanceArray` to assign scores
- The score is assigned using an exponential decay formula (logarithmic scoring)*, giving higher priority to closer users while still giving further users a chance to receive some score. 
- The function returns the `scores` Map that has userIDs as keys and corresponding scores as values after every user has been scored.

Next Steps:
- Add score preferences between current user and suggested user to give weight to similarity using the same logic from TC1.
- Create endpoint to sort and display suggested users using assigned scores from highest to lowest.