### PR TITLE
[Core feature] Distance comparison returns binary value

### DIFF
--- a/server/math/haversineDistanceFormula.js
+++ b/server/math/haversineDistanceFormula.js
@@ -1,0 +1,30 @@
+const { PrismaClient } = require('@prisma/client')
+const prisma = new PrismaClient();
+
+function haversineDistanceFormula(userCoords, postCoords, limitKm = 80) {
+    function toRad(degree) {
+        return degree * (Math.PI / 180);
+    }
+
+    const R = 6371;
+
+    // find difference between the coordinates of both inputs (in radians)
+    const dLat = toRad(userCoords.latitude - postCoords.latitude)
+    const dLon = toRad(userCoords.longitude - postCoords.longitude)
+
+    const { sin, cos, sqrt, atan2 } = Math;
+
+    const a = 
+        sin(dLat / 2) * sin(dLat / 2) +
+        cos(toRad(userCoords.latitude)) * cos(toRad(postCoords.latitude)) *
+        sin(dLon / 2) * sin(dLon / 2);
+
+    const c = 2 * atan2(sqrt(a), sqrt(1 - a));
+
+    const binaryDistance = R * c;
+
+    // returns binary value depending on distance (km)
+    return binaryDistance <= limitKm ? 1 : 0;
+}
+
+module.exports = { haversineDistanceFormula }

--- a/server/utils/compareZipcodes.js
+++ b/server/utils/compareZipcodes.js
@@ -1,4 +1,5 @@
 const { fetchCoordinates } = require('./fetchCoordinates')
+const { haversineDistanceFormula } = require('../math/haversineDistanceFormula');
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
@@ -10,7 +11,10 @@ async function compareZipcodes(user, post) {
         const userCoords = await fetchCoordinates(userZipcode);
         const postCoords = await fetchCoordinates(postZipcode);
 
-        return {userCoords, postCoords};
+        const binaryDistance = haversineDistanceFormula(userCoords, postCoords);
+        
+        // returns 1 if (distance < 80km) ; 0 otherwise
+        return binaryDistance;
 
     } catch (error) {}
 }

--- a/server/utils/fetchCoordinates.js
+++ b/server/utils/fetchCoordinates.js
@@ -8,7 +8,7 @@ async function fetchCoordinates(zipcode) {
         const zipcodeInt = parseInt(zipcode, 10);
         const country = "US";
 
-        const res = await fetch(`https://api.zipcodestack.com/v1/search?apikey=${API_KEY}&codes=${zipcodeInt}&country=${country}`)
+        const res = await fetch(`https://app.zipcodebase.com/api/v1/search?apikey=${API_KEY}&codes=${zipcodeInt}&country=${country}`)
         const locationData = await res.json();
 
         const coordinates = locationData.results[zipcode]?.[0]


### PR DESCRIPTION
Context:
- Zipcode conversion will be used to turn the zipcode inputted by user into latitude and longitude coordinates. These coordinates will be used to calculate the distance between the 2 zipcodes using the Haversine Formula.

Description:
- Changed external API to this one for more free uses:
- https://app.zipcodebase.com/
- compareZipcodes returns a binary value that is determined by the following:
- 1 if difference in distance <= 80km
- 0 if difference in distance > 80km

Next Steps:
- Use this value to add weight to distance when scoring posts.