### PR TITLE
[Core feature] Added distance to scorePost

### DIFF
--- a/server/api/posts.js
+++ b/server/api/posts.js
@@ -76,6 +76,7 @@ posts.post('/discoverPosts', async (req, res) => {
         genres: true,
         eventType: true,
         likedPosts: true,
+        zipcode: true,
       },
     });
 
@@ -84,6 +85,7 @@ posts.post('/discoverPosts', async (req, res) => {
       select: {
         postGenre: true,
         postEventType: true,
+        zipcode: true,
       },
     });
 
@@ -99,17 +101,18 @@ posts.post('/discoverPosts', async (req, res) => {
       }},
     })
 
-    const scoredPosts = posts.map(post => {
-      const score = scorePost(post, user, likedPosts);
-      return { ...post, score };
-    });
+    const scoredPosts = [];
 
+    for (const post of posts) {
+      const score = await scorePost(post, user, likedPosts);
+      scoredPosts.push({ ...post, score });
+    }
+      
     scoredPosts.sort((a, b) => {
       const compareScore = b.score - a.score
         if (compareScore !== 0) {
           return compareScore;
         }
-      
       
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });

--- a/server/utils/fetchCoordinates.js
+++ b/server/utils/fetchCoordinates.js
@@ -5,13 +5,13 @@ const prisma = new PrismaClient();
 async function fetchCoordinates(zipcode) {
     try {
         const API_KEY = process.env.VITE_API_KEY;
-        const zipcodeInt = parseInt(zipcode, 10);
+        const zipcodeStr = String(zipcode);
         const country = "US";
 
-        const res = await fetch(`https://app.zipcodebase.com/api/v1/search?apikey=${API_KEY}&codes=${zipcodeInt}&country=${country}`)
+        const res = await fetch(`https://app.zipcodebase.com/api/v1/search?apikey=${API_KEY}&codes=${zipcodeStr}&country=${country}`)
         const locationData = await res.json();
 
-        const coordinates = locationData.results[zipcode]?.[0]
+        const coordinates = locationData.results[zipcodeStr]?.[0]
 
         return { latitude: coordinates.latitude, longitude: coordinates.longitude };
         


### PR DESCRIPTION
Context:
- Zipcode conversion will be used to turn the zipcode inputted by user into latitude and longitude coordinates. These coordinates will be used to calculate the distance between the 2 zipcodes using the Haversine Formula.

Description:
- Added weight to `scorePosts` for posts whose zipcode was found in the API
- Weight distribution is now `{userPrefSim = 0.3, likedPostSim = 0.6, distanceSim = 0.1}`

Issues:
- Since some zipcodes were not in the API database, the distanceSimilarity defaults to 0 if there is no result.
- Because of this, I added very little weight to the distance similarity.

Next Steps:
- Add the loading state for when posts are loading.